### PR TITLE
Capability to change the list of monitors in the existing Ceph PV

### DIFF
--- a/2020/04-etcdhelper/README.md
+++ b/2020/04-etcdhelper/README.md
@@ -49,6 +49,11 @@ go build -o etcdhelper etcdhelper.go
 ./etcdhelper -cacert /etc/kubernetes/pki/etcd/ca.crt -cert /etc/kubernetes/pki/etcd/server.crt -key /etc/kubernetes/pki/etcd/server.key -endpoint https://127.0.0.1:2379 change-pod-cidr 10.55.0.0/16
 ```
 
+### Change Ceph PV monitors list
+```shell
+./etcdhelper -cacert /etc/kubernetes/pki/etcd/ca.crt -cert /etc/kubernetes/pki/etcd/server.crt -key /etc/kubernetes/pki/etcd/server.key -endpoint https://127.0.0.1:2379 change-monitors-list pvc-d748b019-52be-4c0c-a928-44503ccd94ac 10.0.1.1:6789,10.0.1.2:6789,10.0.1.3:6789
+```
+
 # Status
 
 This enhanced version of etcdhelper is **PoC (proof of concept)**. Use it on your own risk.

--- a/2020/04-etcdhelper/go.mod
+++ b/2020/04-etcdhelper/go.mod
@@ -1,0 +1,15 @@
+module etcdhelper
+
+go 1.14
+
+require (
+	github.com/coreos/etcd v3.3.20+incompatible // indirect
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/gardener/machine-controller-manager v0.29.0
+	go.etcd.io/etcd v3.3.20+incompatible
+	go.uber.org/zap v1.15.0 // indirect
+	k8s.io/api v0.17.2
+	k8s.io/apimachinery v0.17.2
+	k8s.io/kubectl v0.17.2
+)


### PR DESCRIPTION
Most of the fields in the PersistentVolume object are immutable. In some cases it might be useful to change list of PV's ceph monitors, eg: when you moving your monitors to the new hardware and not able (or not willing)  to move it with the IP-address.